### PR TITLE
fix compile bug on linux and windows (e0015)

### DIFF
--- a/bins/wallet/src/root/platform_attention.rs
+++ b/bins/wallet/src/root/platform_attention.rs
@@ -3,7 +3,7 @@ pub(super) struct PlatformAttentionState {
 }
 
 impl PlatformAttentionState {
-    pub(super) const fn new(window: &gpui::Window) -> Self {
+    pub(super) fn new(window: &gpui::Window) -> Self {
         Self {
             native: imp::NativePlatformAttentionState::new(window),
         }


### PR DESCRIPTION
const fn on the platform attention state outer was causing compile issues on windows and linux due to neither inner new being a const, linux could have an inner const but windows can't so the easiest fix seems to be to drop the const from the outer since macos doesn't need it to compile. 

tested with cargo check -p wallet and nix build